### PR TITLE
Handle multiple precision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
-Krylov = "0.3"
-LinearOperators = "0.5, 0.6"
-NLPModels = "0.7, 0.8, 0.9"
+Krylov = "0.3, 0.4"
+LinearOperators = "0.6, 0.7, 1"
+NLPModels = "0.7, 0.8, 0.9, 0.10, 0.11"
 SolverTools = "0.1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSOSolvers"
 uuid = "10dff2fc-5484-5881-a0e0-c90441020f8a"
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"

--- a/src/tron.jl
+++ b/src/tron.jl
@@ -74,7 +74,8 @@ function tron(nlp :: AbstractNLPModel;
     xc .= x
     fc = fx
     Δ = get_property(tr, :radius)
-    H = hess_op!(nlp, xc, temp)
+    # H = hess_op!(nlp, xc, temp) # hess_op ignores the type of x in NLPModels 0.10-0.11
+    H = LinearOperator(T, n, n, true, true, v -> hprod!(nlp, xc, v, temp))
 
     αC, s, cauchy_status = cauchy(x, H, gx, Δ, αC, ℓ, u, μ₀=μ₀, μ₁=μ₁, σ=σ)
 

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -68,7 +68,8 @@ function trunk(nlp :: AbstractNLPModel;
     # Compute inexact solution to trust-region subproblem
     # minimize g's + 1/2 s'Hs  subject to ‖s‖ ≤ radius.
     # In this particular case, we may use an operator with preallocation.
-    H = hess_op!(nlp, x, temp)
+    # H = hess_op!(nlp, x, temp) # hess_op ignores the type of x in NLPModels 0.10-0.11
+    H = LinearOperator(T, n, n, true, true, v -> hprod!(nlp, x, v, temp))
     cgtol = max(rtol, min(T(0.1), 9 * cgtol / 10, sqrt(∇fNorm2)))
     (s, cg_stats) = with_logger(subsolver_logger) do
       cg(H, -∇f,

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -46,7 +46,8 @@ function trunk(nlp :: AbstractNLSModel;
   # preallocate storage for products with A and A'
   Av = Vector{T}(undef, m)
   Atv = Vector{T}(undef, n)
-  A = jac_op_residual!(nlp, x, Av, Atv)
+  # A = jac_op_residual!(nlp, x, Av, Atv) # jac_op ignores the type of x in NLPModels 0.10-0.11
+  A = LinearOperator(T, m, n, false, false, v -> jprod_residual!(nlp, x, v, Av), nothing, v -> jtprod_residual!(nlp, x, v, Atv))
   ∇f = A' * r
   ∇fNorm2 = nrm2(n, ∇f)
   ϵ = atol + rtol * ∇fNorm2
@@ -197,7 +198,8 @@ function trunk(nlp :: AbstractNLSModel;
       x .= xt
       r = rt
       f = ft
-      A = jac_op_residual!(nlp, x, Av, Atv)
+      # A = jac_op_residual!(nlp, x, Av, Atv) # jac_op ignores the type of x in NLPModels 0.10-0.11
+      A = LinearOperator(T, m, n, false, false, v -> jprod_residual!(nlp, x, v, Av), nothing, v -> jtprod_residual!(nlp, x, v, Atv))
       ∇f = A' * r
       ∇fNorm2 = nrm2(n, ∇f)
     end


### PR DESCRIPTION
The `matrix_op` functions return operators with `Float64` types, so we explicitly
define the operators with `eltype(x)` here.

After https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/248 this can be reverted, updating the version limits.