### PR TITLE
Allow the use of NLP trunk for NLS problems dispatching with Val{:Newton}

### DIFF
--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -1,5 +1,7 @@
 export trunk
 
+trunk(nlp :: AbstractNLPModel; variant=:Newton, kwargs...) = trunk(Val(:Newton), nlp; kwargs...)
+
 """
     trunk(nlp)
 
@@ -15,7 +17,8 @@ The nonmonotone strategy follows Section 10.1.3, Algorithm 10.1.2.
     SIAM, Philadelphia, USA, 2000.
     DOI: 10.1137/1.9780898719857.
 """
-function trunk(nlp :: AbstractNLPModel;
+function trunk(::Val{:Newton},
+               nlp :: AbstractNLPModel;
                subsolver_logger :: AbstractLogger=NullLogger(),
                x :: AbstractVector=copy(nlp.meta.x0),
                atol :: Real=√eps(eltype(x)), rtol :: Real=√eps(eltype(x)),

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -1,5 +1,7 @@
 const trunkls_allowed_subsolvers = [:cgls, :crls, :lsqr, :lsmr]
 
+trunk(nlp :: AbstractNLSModel; variant=:GaussNewton, kwargs...) = trunk(Val(:GaussNewton), nlp; kwargs...)
+
 """
     trunk(nls)
 
@@ -15,7 +17,8 @@ The nonmonotone strategy follows Section 10.1.3, Algorithm 10.1.2.
     SIAM, Philadelphia, USA, 2000.
     DOI: 10.1137/1.9780898719857.
 """
-function trunk(nlp :: AbstractNLSModel;
+function trunk(::Val{:GaussNewton},
+               nlp :: AbstractNLSModel;
                x :: AbstractVector=copy(nlp.meta.x0),
                subsolver :: Symbol=:lsmr,
                atol :: Real=√eps(eltype(x)), rtol :: Real=√eps(eltype(x)),

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -17,8 +17,11 @@ function test_solvers()
 
   @info "Testing NLS solvers"
   @info "  unconstrained solvers"
-  for solver in [(nls; kwargs...) -> trunk(nls, subsolver=:cgls; kwargs...)] # trunk with cgls due to multiprecision
-    @info "    $solver"
+  for (name,solver) in [
+         ("trunk+cgls", (nls; kwargs...) -> trunk(nls, subsolver=:cgls; kwargs...)), # trunk with cgls due to multiprecision
+         ("trunk full Hessian", (nls; kwargs...) -> trunk(nls, variant=:Newton; kwargs...))
+       ]
+    @info "    $name"
     test_unconstrained_nls_solver(solver)
   end
 end


### PR DESCRIPTION
For `nlp :: NLP` problems we have `trunk(nlp)`.
For `nls :: NLS` problems we have `trunk(nls)` with uses the specialized version and `trunk(nls, variant=:NLP)` which uses the original version with full Hessian.