### PR TITLE
Add objgrad to tron

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSOSolvers"
 uuid = "10dff2fc-5484-5881-a0e0-c90441020f8a"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"

--- a/test/objgrad-on-tron.jl
+++ b/test/objgrad-on-tron.jl
@@ -1,0 +1,37 @@
+@testset "objgrad on tron" begin
+  struct MyProblem <: AbstractNLPModel
+    meta :: NLPModelMeta
+    counters :: Counters
+  end
+
+  function MyProblem()
+    meta = NLPModelMeta(
+      2, # nvar
+      x0 = [0.1; 0.1],
+      lvar=zeros(2),
+      uvar=ones(2)
+    )
+    MyProblem(meta, Counters())
+  end
+
+  function NLPModels.objgrad!(:: MyProblem, x :: AbstractVector, g:: AbstractVector)
+    f = (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2
+    g[1] = 2 * (x[1] - 1) - 400 * x[1] * (x[2] - x[1]^2)
+    g[2] = 200 * (x[2] - x[1]^2)
+    f, g
+  end
+
+  function NLPModels.hprod!(:: MyProblem, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+    Hv[1] = obj_weight * (2 - 400 * (x[2] - x[1]^2) + 800 * x[1]^2) * v[1] - 400obj_weight * x[1] * v[2]
+    Hv[2] = 200obj_weight * v[2] - 400obj_weight * x[1] * v[1]
+    Hv
+  end
+
+  nlp = MyProblem()
+  output = tron(nlp, use_only_objgrad=true)
+  @test isapprox(output.solution, ones(2), rtol=1e-4)
+  @test output.dual_feas < 1e-4
+  @test output.objective< 1e-4
+
+  @test_throws MethodError tron(nlp, use_only_objgrad=false)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,3 +23,5 @@ for solver in [trunk]
   solver(nlp, max_eval=20)
   reset!(nlp)
 end
+
+include("objgrad-on-tron.jl")


### PR DESCRIPTION
The keyword option `use_only_objgrad` is also included models without individual `obj` functions.

Related to https://discourse.julialang.org/t/is-there-a-julia-equivalent-of-scipy-optimize-minimize-method-tnc/45154/10

Satisfy #30 for `tron`.