### PR TITLE
Fix bug: stop when encounters an error

### DIFF
--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -185,6 +185,7 @@ function SolverCore.solve!(
     if slope ≥ 0
       @error "not a descent direction" slope
       set_status!(stats, :not_desc)
+      done = true
       continue
     end
 

--- a/src/tron.jl
+++ b/src/tron.jl
@@ -233,6 +233,7 @@ function SolverCore.solve!(
     if cauchy_status != :success
       @error "Cauchy step returned: $cauchy_status"
       status = cauchy_status
+      done = true
       continue
     end
     s, Hs, cgits, cginfo = with_logger(subsolver_logger) do
@@ -249,6 +250,7 @@ function SolverCore.solve!(
     ared, pred = aredpred!(tr, nlp, fc, fx, qs, x, s, slope)
     if pred ≥ 0
       status = :neg_pred
+      done = true
       continue
     end
     tr.ratio = ared / pred

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -251,6 +251,7 @@ function SolverCore.solve!(
     if cauchy_status != :success
       @error "Cauchy step returned: $cauchy_status"
       status = cauchy_status
+      done = true
       continue
     end
     s, As, cgits, cginfo = with_logger(subsolver_logger) do
@@ -275,6 +276,7 @@ function SolverCore.solve!(
     ared, pred = aredpred!(tr, nlp, fc, fx, qs, x, s, slope)
     if pred ≥ 0
       status = :neg_pred
+      done = true
       continue
     end
     tr.ratio = ared / pred

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -252,6 +252,7 @@ function SolverCore.solve!(
     ared, pred = aredpred!(tr, nlp, f, ft, Δq, xt, s, slope)
     if pred ≥ 0
       status = :neg_pred
+      done = true
       continue
     end
     tr.ratio = ared / pred
@@ -260,6 +261,7 @@ function SolverCore.solve!(
       ared_hist, pred_hist = aredpred!(tr, nlp, fref, ft, σref + Δq, xt, s, slope)
       if pred_hist ≥ 0
         status = :neg_pred
+        done = true
         continue
       end
       ρ_hist = ared_hist / pred_hist
@@ -279,6 +281,7 @@ function SolverCore.solve!(
       if slope ≥ 0
         @error "not a descent direction: slope = $slope, ‖∇f‖ = $∇fNorm2"
         status = :not_desc
+        done = true
         continue
       end
       α = one(T)
@@ -295,6 +298,7 @@ function SolverCore.solve!(
       ared, pred = aredpred!(tr, nlp, f, ft, Δq, xt, s, slope)
       if pred ≥ 0
         status = :neg_pred
+        done = true
         continue
       end
       tr.ratio = ared / pred
@@ -302,6 +306,7 @@ function SolverCore.solve!(
         ared_hist, pred_hist = aredpred!(tr, nlp, fref, ft, σref + Δq, xt, s, slope)
         if pred_hist ≥ 0
           status = :neg_pred
+          done = true
           continue
         end
         ρ_hist = ared_hist / pred_hist

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -262,6 +262,7 @@ function SolverCore.solve!(
     ared, pred = aredpred!(tr, nlp, f, ft, Δq, xt, s, slope)
     if pred ≥ 0
       status = :neg_pred
+      done = true
       continue
     end
     tr.ratio = ared / pred
@@ -270,6 +271,7 @@ function SolverCore.solve!(
       ared_hist, pred_hist = aredpred!(tr, nlp, fref, ft, σref + Δq, xt, s, slope)
       if pred_hist ≥ 0
         status = :neg_pred
+        done = true
         continue
       end
       ρ_hist = ared_hist / pred_hist
@@ -289,6 +291,7 @@ function SolverCore.solve!(
       if slope ≥ 0
         @error "not a descent direction" slope ∇fNorm2 sNorm
         status = :not_desc
+        done = true
         continue
       end
       α = one(T)
@@ -308,6 +311,7 @@ function SolverCore.solve!(
       ared, pred = aredpred!(tr, nlp, f, ft, Δq, xt, s, slope)
       if pred ≥ 0
         status = :neg_pred
+        done = true
         continue
       end
       tr.ratio = ared / pred
@@ -315,6 +319,7 @@ function SolverCore.solve!(
         ared_hist, pred_hist = aredpred!(tr, nlp, fref, ft, σref + Δq, xt, s, slope)
         if pred_hist ≥ 0
           status = :neg_pred
+          done = true
           continue
         end
         ρ_hist = ared_hist / pred_hist


### PR DESCRIPTION
I removed `stalled=true`, but then `continue` skips the test to stop.

Noticed this in https://github.com/JuliaSmoothOptimizers/CaNNOLeS.jl/pull/56 with problem NLSProblems.mgh11.