### PR TITLE
Review logs

### DIFF
--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -163,6 +163,7 @@ function SolverCore.solve!(
     [Int, T, T, T, Int],
     hdr_override = Dict(:f => "f(x)", :dual => "‖∇f‖", :slope => "∇fᵀd"),
   )
+  verbose > 0 && @info log_row(Any[stats.iter, f, ∇fNorm, T, Int])
 
   optimal = ∇fNorm ≤ ϵ
 
@@ -197,10 +198,6 @@ function SolverCore.solve!(
     t, good_grad, ft, nbk, nbW =
       armijo_wolfe(h, f, slope, ∇ft, τ₁ = τ₁, bk_max = bk_max, verbose = Bool(verbose_subsolver))
 
-    verbose > 0 &&
-      mod(stats.iter, verbose) == 0 &&
-      @info log_row(Any[stats.iter, f, ∇fNorm, slope, nbk])
-
     copyaxpy!(n, t, d, x, xt)
     good_grad || grad!(nlp, xt, ∇ft)
 
@@ -216,8 +213,13 @@ function SolverCore.solve!(
 
     ∇fNorm = nrm2(n, ∇f)
 
-    set_objective!(stats, f)
     set_iter!(stats, stats.iter + 1)
+
+    verbose > 0 &&
+      mod(stats.iter, verbose) == 0 &&
+      @info log_row(Any[stats.iter, f, ∇fNorm, slope, nbk])
+
+    set_objective!(stats, f)
     set_time!(stats, time() - start_time)
     set_dual_residual!(stats, ∇fNorm)
     optimal = ∇fNorm ≤ ϵ

--- a/src/tron.jl
+++ b/src/tron.jl
@@ -263,6 +263,7 @@ function SolverCore.solve!(
     [Int, T, T, T, T, String],
     hdr_override = Dict(:f => "f(x)", :dual => "π", :radius => "Δ"),
   )
+  verbose > 0 && @info log_row([stats.iter, fx, πx, T, T, String])
 
   set_status!(
     stats,

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -303,6 +303,7 @@ function SolverCore.solve!(
     [Int, T, T, T, T, String],
     hdr_override = Dict(:f => "f(x)", :dual => "π", :radius => "Δ"),
   )
+  verbose > 0 && @info log_row([stats.iter, fx, πx, T, T, String])
 
   set_status!(
     stats,
@@ -353,9 +354,6 @@ function SolverCore.solve!(
       continue
     end
     tr.ratio = ared / pred
-    verbose > 0 &&
-      mod(stats.iter, verbose) == 0 &&
-      @info log_row([stats.iter, fx, πx, Δ, tr.ratio, cginfo])
 
     s_norm = nrm2(n, s)
     if num_success_iters == 0
@@ -394,6 +392,10 @@ function SolverCore.solve!(
     project_step!(gpx, x, x, ℓ, u, zero(T)) # Proj(x) - x
     small_residual = (norm(gpx) <= ϵ) && (2 * √fx <= ϵF)
     unbounded = fx < fmin
+
+    verbose > 0 &&
+      mod(stats.iter, verbose) == 0 &&
+      @info log_row([stats.iter, fx, πx, Δ, tr.ratio, cginfo])
 
     set_status!(
       stats,

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -215,6 +215,7 @@ function SolverCore.solve!(
     [Int, T, T, T, T, Int, Int, String],
     hdr_override = Dict(:f => "f(x)", :dual => "π", :radius => "Δ"),
   )
+  verbose > 0 && @info log_row([stats.iter, f, ∇fNorm2, T, T, Int, Int, String])
 
   set_status!(
     stats,
@@ -325,18 +326,6 @@ function SolverCore.solve!(
       end
     end
 
-    verbose > 0 &&
-      mod(stats.iter, verbose) == 0 &&
-      @info log_row([
-        stats.iter,
-        f,
-        ∇fNorm2,
-        tr.radius,
-        tr.ratio,
-        length(cg_stats.residuals),
-        bk,
-        cg_stats.status,
-      ])
     set_iter!(stats, stats.iter + 1)
 
     if acceptable(tr)
@@ -385,6 +374,17 @@ function SolverCore.solve!(
         push!(nlp, s, ∇fn)
         ∇fn .= ∇f
       end
+
+      verbose > 0 && mod(stats.iter, verbose) == 0 && @info log_row([
+        stats.iter,
+        f,
+        ∇fNorm2,
+        tr.radius,
+        tr.ratio,
+        length(cg_stats.residuals),
+        bk,
+        cg_stats.status,
+      ])
     end
 
     # Move on.

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -243,6 +243,7 @@ function SolverCore.solve!(
     [Int, T, T, T, T, T, Int, Int, String],
     hdr_override = Dict(:f => "f(x)", :dual => "‖∇f‖", :radius => "Δ"),
   )
+  verbose > 0 && @info log_row([stats.iter, f, ∇fNorm2, T, T, T, Int, Int, String])
 
   set_status!(
     stats,
@@ -356,19 +357,6 @@ function SolverCore.solve!(
       end
     end
 
-    verbose > 0 &&
-      mod(stats.iter, verbose) == 0 &&
-      @info log_row([
-        stats.iter,
-        f,
-        ∇fNorm2,
-        tr.radius,
-        sNorm,
-        tr.ratio,
-        length(cg_stats.residuals),
-        bk,
-        cg_stats.status,
-      ])
     set_iter!(stats, stats.iter + 1)
 
     if acceptable(tr)
@@ -415,6 +403,20 @@ function SolverCore.solve!(
     set_objective!(stats, f)
     set_time!(stats, time() - start_time)
     set_dual_residual!(stats, ∇fNorm2)
+
+    verbose > 0 &&
+      mod(stats.iter, verbose) == 0 &&
+      @info log_row([
+        stats.iter,
+        f,
+        ∇fNorm2,
+        tr.radius,
+        sNorm,
+        tr.ratio,
+        length(cg_stats.residuals),
+        bk,
+        cg_stats.status,
+      ])
 
     optimal = ∇fNorm2 ≤ ϵ
     small_residual = 2 * √f ≤ ϵF


### PR DESCRIPTION
Close #207 

```
julia> using JSOSolvers
[ Info: Precompiling JSOSolvers [10dff2fc-5484-5881-a0e0-c90441020f8a]
WARNING: ignoring conflicting import of Krylov.solve! into JSOSolvers

julia> using NLPModels

julia> using ADNLPModels

julia> f(x) = sum(x.^2)
f (generic function with 1 method)

julia> model = ADNLPModel(f, ones(4))
ADNLPModel - Model with automatic differentiation backend ADModelBackend{
  ForwardDiffADGradient,
  ForwardDiffADHvprod,
  ForwardDiffADJprod,
  ForwardDiffADJtprod,
  SparseADJacobian,
  SparseADHessian,
  ForwardDiffADGHjvprod,
}
  Problem name: Generic
   All variables: ████████████████████ 4      All constraints: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
            free: ████████████████████ 4                 free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
         low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
          infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
            nnzh: ( 60.00% sparsity)   4               linear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
                                                    nonlinear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
                                                         nnzj: (------% sparsity)         

  Counters:
             obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
        cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
         jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
       jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0           jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
      jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     


julia> function my_callback(nlp, solver, stats)
           println("Iter ", stats.iter, "\tObjective ", obj(nlp, solver.x))
       end
my_callback (generic function with 1 method)

julia> println("at start\t objective: ", obj(model, model.meta.x0))
at start         objective: 4.0

julia> tron(model; verbose = 1, callback = my_callback)
[ Info:   iter      f(x)         π         Δ     ratio         cgstatus  
[ Info:      0   4.0e+00   4.0e+00         -         -                -
Iter 0  Objective 4.0
[ Info:      1   3.6e-01   1.2e+00   1.0e+00   1.0e+00  on trust-region boundary
Iter 1  Objective 0.36000000000000026
[ Info:      2   0.0e+00   0.0e+00   2.0e+00   1.0e+00  stationary point found
Iter 2  Objective 0.0
[ Info:      2   0.0e+00   0.0e+00   2.0e+00
"Execution stats: first-order stationary"

julia> trunk(model; verbose = 1, callback = my_callback)
[ Info:   iter      f(x)         π         Δ     ratio   inner      bk         cgstatus  
[ Info:      0   4.0e+00   4.0e+00         -         -       -       -                -
Iter 0  Objective 4.0
[ Info:      1   1.0e+00   2.0e+00   1.0e+00   1.0e+00       0       0  on trust-region boundary
Iter 1  Objective 1.0
[ Info:      2   0.0e+00   0.0e+00   1.5e+00   1.0e+00       0       0  solution good enough given atol and rtol
Iter 2  Objective 0.0
[ Info:      2   0.0e+00   0.0e+00   1.5e+00
"Execution stats: first-order stationary"

julia> model = ADNLSModel(x -> [x[1]^2 - 0.5; x[2]], ones(4), 2)
ADNLSModel - Nonlinear least-squares model with automatic differentiation backend ADModelBackend{
  ForwardDiffADGradient,
  ForwardDiffADHvprod,
  ForwardDiffADJprod,
  ForwardDiffADJtprod,
  SparseADJacobian,
  SparseADHessian,
  ForwardDiffADGHjvprod,
}
  Problem name: Generic
   All variables: ████████████████████ 4      All constraints: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0        All residuals: ████████████████████ 2     
            free: ████████████████████ 4                 free: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               linear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                lower: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            nonlinear: ████████████████████ 2     
           upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                upper: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 nnzj: ( 75.00% sparsity)   2     
         low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              low/upp: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 nnzh: (  0.00% sparsity)   10    
           fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                fixed: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
          infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               infeas: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
            nnzh: ( 80.00% sparsity)   2               linear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
                                                    nonlinear: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
                                                         nnzj: (------% sparsity)         

  Counters:
             obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 grad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 cons: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
        cons_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             cons_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 jcon: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           jgrad: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                  jac: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0              jac_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
         jac_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                jprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0            jprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
       jprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jtprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0           jtprod_lin: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
      jtprod_nln: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                 hess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0                hprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
           jhess: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0               jhprod: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0             residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
    jac_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0       jprod_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0      jtprod_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     
   hess_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0       jhess_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0       hprod_residual: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0     


julia> tron(model; verbose = 1, callback = my_callback)
[ Info:   iter      f(x)         π         Δ     ratio         cgstatus  
[ Info:      0   6.2e-01   1.4e+00         -         -                -
Iter 0  Objective 0.625
[ Info:      1   2.0e-03   9.4e-02   1.0e+00   1.0e+00  stationary point found
Iter 1  Objective 0.001953125
[ Info:      2   1.5e-06   2.5e-03   1.0e+00   1.0e+00  stationary point found
Iter 2  Objective 1.507040895061814e-6
[ Info:      3   1.1e-12   2.1e-06   1.0e+00   1.0e+00  stationary point found
Iter 3  Objective 1.1277409986177804e-12
[ Info:      4   6.4e-25   1.6e-12   1.0e+00   1.0e+00  stationary point found
Iter 4  Objective 6.358012377306299e-25
[ Info:      4   6.4e-25   1.6e-12   1.0e+00
"Execution stats: first-order stationary"

julia> trunk(model; verbose = 1, callback = my_callback)
[ Info:   iter      f(x)      ‖∇f‖         Δ      step     ratio   inner      bk         cgstatus  
[ Info:      0   6.2e-01   1.4e+00         -         -         -       -       -                -
Iter 0  Objective 0.625
[ Info:      1   2.3e-03   9.5e-02   1.5e+00   1.0e+00   1.0e+00       0       0  on trust-region boundary
Iter 1  Objective 0.002289732046230763
[ Info:      2   1.2e-06   2.2e-03   1.5e+00   5.1e-02   1.0e+00       0       0  found approximate zero-residual solution
Iter 2  Objective 1.2494287285010376e-6
[ Info:      3   7.8e-13   1.8e-06   1.5e+00   1.1e-03   1.0e+00       0       0  found approximate zero-residual solution
Iter 3  Objective 7.756239655987268e-13
[ Info:      4   3.0e-25   1.1e-12   1.5e+00   8.8e-07   1.0e+00       0       0  found approximate zero-residual solution
Iter 4  Objective 3.0069297702836446e-25
[ Info:      4   3.0e-25   1.1e-12   1.5e+00
"Execution stats: first-order stationary"
```