### PR TITLE
Removed unnecessary code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ LinearOperators = "1.1, 2.0"
 NLPModels = "0.20"
 NLPModelsModifiers = "0.6"
 SolverCore = "0.3"
-SolverTools = "0.8"
+SolverTools = "0.8.6"
 julia = "1.6"
 
 [extras]

--- a/docs/src/internal.md
+++ b/docs/src/internal.md
@@ -4,7 +4,6 @@
 JSOSolvers.projected_newton!
 JSOSolvers.projected_line_search!
 JSOSolvers.cauchy!
-JSOSolvers.compute_As_slope_qs!
 JSOSolvers.projected_gauss_newton!
 JSOSolvers.projected_line_search_ls!
 JSOSolvers.cauchy_ls!

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -1,4 +1,4 @@
-export TronSolverNLS, SolverTools
+export TronSolverNLS
 
 const tronls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolver]
 

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -1,25 +1,8 @@
-export TronSolverNLS
+export TronSolverNLS, SolverTools
 
 const tronls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolver]
 
 tron(nls::AbstractNLSModel; variant = :GaussNewton, kwargs...) = tron(Val(variant), nls; kwargs...)
-
-"""
-    slope, qs = compute_As_slope_qs!(As, A, s, Fx)
-
-Compute `slope = dot(As, Fx)` and `qs = dot(As, As) / 2 + slope`. Use `As` to store `A * s`.
-"""
-function compute_As_slope_qs!(
-  As::AbstractVector{T},
-  A::Union{AbstractMatrix, AbstractLinearOperator},
-  s::AbstractVector{T},
-  Fx::AbstractVector{T},
-) where {T <: Real}
-  mul!(As, A, s)
-  slope = dot(As, Fx)
-  qs = dot(As, As) / 2 + slope
-  return slope, qs
-end
 
 """
     tron(nls; kwargs...)


### PR DESCRIPTION
This PR is a follow up of  https://github.com/JuliaSmoothOptimizers/SolverTools.jl/issues/196
Here , the unnecessary function of compute_As_slope_qs!() is removed as it is 
already exported from SolverTools.jl repo