### PR TITLE
Use SolverParameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
+SolverParameters = "d076d87d-d1f9-4ea3-a44b-64b4cdd1e470"
 SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
@@ -19,6 +20,7 @@ LinearOperators = "2.0"
 NLPModels = "0.21"
 NLPModelsModifiers = "0.7"
 SolverCore = "0.3"
+SolverParameters = "0.1"
 SolverTools = "0.9"
 julia = "1.6"
 

--- a/src/JSOSolvers.jl
+++ b/src/JSOSolvers.jl
@@ -4,7 +4,8 @@ module JSOSolvers
 using LinearAlgebra, Logging, Printf
 
 # JSO packages
-using Krylov, LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverParameters, SolverTools
+using Krylov,
+  LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverParameters, SolverTools
 
 import SolverCore.solve!
 export solve!

--- a/src/JSOSolvers.jl
+++ b/src/JSOSolvers.jl
@@ -4,7 +4,7 @@ module JSOSolvers
 using LinearAlgebra, Logging, Printf
 
 # JSO packages
-using Krylov, LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverTools
+using Krylov, LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverParameters, SolverTools
 
 import SolverCore.solve!
 export solve!

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -23,7 +23,7 @@ const FOMO_step_backend = :r2_step
 """
     FOMOParameterSet{T} <: AbstractParameterSet
 
-This structure designed for `lbfgs` regroups the following parameters:
+This structure designed for `fomo` regroups the following parameters:
   - `η1 = $(FOMO_η1)`, `η2 = T($(FOMO_η2))`: step acceptance parameters.
   - `γ1 = T($(FOMO_γ1))`, `γ2 = T($(FOMO_γ2))`: regularization update parameters.
   - `γ3 = T($(FOMO_γ3))` : momentum factor βmax update parameter in case of unsuccessful iteration.
@@ -81,10 +81,10 @@ function FOMOParameterSet{T}(;
     Parameter(η2, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
     Parameter(γ1, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
     Parameter(γ2, RealInterval(T(1), T(Inf), lower_open = true, upper_open = true)),
-    Parameter(γ3, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
+    Parameter(γ3, RealInterval(T(0), T(1))),
     Parameter(αmax, RealInterval(T(1), T(Inf), upper_open = true)),
     Parameter(β, RealInterval(T(0), T(1), upper_open = true)),
-    Parameter(θ1, RealInterval(T(0), T(1), upper_open = true)),
+    Parameter(θ1, RealInterval(T(0), T(1))),
     Parameter(θ2, RealInterval(T(0), T(1), upper_open = true)),
     Parameter(M, IntegerRange(Int(1), typemax(Int))),
     Parameter(step_backend, CategoricalSet{Union{tr_step, r2_step}}([r2_step(); tr_step()])),

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -1,4 +1,5 @@
-export fomo, FomoSolver, FomoParameterSet, FoSolver, fo, R2, TR, tr_step, r2_step
+export fomo, FomoSolver, FOMOParameterSet, FoSolver, fo, R2, TR
+export tr_step, r2_step
 
 abstract type AbstractFirstOrderSolver <: AbstractOptimizationSolver end
 
@@ -20,7 +21,7 @@ const FOMO_M = 1
 const FOMO_step_backend = :r2_step
 
 """
-    FomoParameterSet{T} <: AbstractParameterSet
+    FOMOParameterSet{T} <: AbstractParameterSet
 
 This structure designed for `lbfgs` regroups the following parameters:
   - `η1 = $(FOMO_η1)`, `η2 = T($(FOMO_η2))`: step acceptance parameters.
@@ -46,7 +47,7 @@ This structure designed for `lbfgs` regroups the following parameters:
   - `M = $(FOMO_M)`
   - `step_backend = $FOMO_step_backend()
 """
-struct FomoParameterSet{T} <: AbstractParameterSet
+struct FOMOParameterSet{T} <: AbstractParameterSet
   η1::Parameter{T, RealInterval{T}}
   η2::Parameter{T, RealInterval{T}}
   γ1::Parameter{T, RealInterval{T}}
@@ -61,7 +62,7 @@ struct FomoParameterSet{T} <: AbstractParameterSet
 end
 
 # add a default constructor
-function FomoParameterSet{T}(;
+function FOMOParameterSet{T}(;
   η1::T = eps(T)^(1 // 4),
   η2::T = T(FOMO_η2),
   γ1::T = T(FOMO_γ1),
@@ -75,7 +76,7 @@ function FomoParameterSet{T}(;
   step_backend::AbstractFOMethod = eval(FOMO_step_backend)(),
 ) where {T}
   @assert η1 <= η2
-  FomoParameterSet(
+  FOMOParameterSet(
     Parameter(η1, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
     Parameter(η2, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
     Parameter(γ1, RealInterval(T(0), T(1), lower_open = true, upper_open = true)),
@@ -89,7 +90,7 @@ function FomoParameterSet{T}(;
     Parameter(step_backend, CategoricalSet{Union{tr_step, r2_step}}([r2_step(); tr_step()])),
   )
 end
-FomoParameterSet(
+FOMOParameterSet(
   η1::T,
   η2::T,
   γ1::T,
@@ -101,7 +102,7 @@ FomoParameterSet(
   θ2::T,
   M::Int,
   step_backend::AbstractFOMethod,
-) where {T} = FomoParameterSet{T}(;
+) where {T} = FOMOParameterSet{T}(;
   η1 = η1,
   η2 = η2,
   γ1 = γ1,
@@ -222,11 +223,11 @@ mutable struct FomoSolver{T, V} <: AbstractFirstOrderSolver
   p::V
   o::V
   α::T
-  params::FomoParameterSet{T}
+  params::FOMOParameterSet{T}
 end
 
 function FomoSolver(nlp::AbstractNLPModel{T, V}; M::Int = FOMO_M, kwargs...) where {T, V}
-  params = FomoParameterSet{T}(; M = M, kwargs...)
+  params = FOMOParameterSet{T}(; M = M, kwargs...)
   x = similar(nlp.meta.x0)
   g = similar(nlp.meta.x0)
   c = similar(nlp.meta.x0)
@@ -351,11 +352,11 @@ mutable struct FoSolver{T, V} <: AbstractFirstOrderSolver
   c::V
   o::V
   α::T
-  params::FomoParameterSet{T}
+  params::FOMOParameterSet{T}
 end
 
 function FoSolver(nlp::AbstractNLPModel{T, V}; M::Int = FOMO_M, kwargs...) where {T, V}
-  params = FomoParameterSet{T}(; M = M, kwargs...)
+  params = FOMOParameterSet{T}(; M = M, kwargs...)
   x = similar(nlp.meta.x0)
   g = similar(nlp.meta.x0)
   c = similar(nlp.meta.x0)

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -1,4 +1,4 @@
-export fomo, FomoSolver, FoSolver, fo, R2, TR, tr_step, r2_step
+export fomo, FomoSolver, FomoParameterSet, FoSolver, fo, R2, TR, tr_step, r2_step
 
 abstract type AbstractFirstOrderSolver <: AbstractOptimizationSolver end
 
@@ -6,7 +6,8 @@ abstract type AbstractFOMethod end
 struct tr_step <: AbstractFOMethod end
 struct r2_step <: AbstractFOMethod end
 
-const FOMO_η1 = "eps(T)^(1 / 4)" # TODO
+# Default algorithm parameter values
+const FOMO_η1 = "eps(T)^(1 // 4)" # TODO: handle values that depend on T
 const FOMO_η2 = 95 // 100
 const FOMO_γ1 = 1 // 2
 const FOMO_γ2 = 2
@@ -14,7 +15,7 @@ const FOMO_γ3 = 1 // 2
 const FOMO_αmax = "1 / eps(T)" # TODO
 const FOMO_β = 9 // 10
 const FOMO_θ1 = 1 // 10
-const FOMO_θ2 = "eps(T)^(1 / 3)" # TODO
+const FOMO_θ2 = "eps(T)^(1 // 3)" # TODO
 const FOMO_M = 1
 const FOMO_step_backend = :r2_step
 
@@ -22,13 +23,13 @@ const FOMO_step_backend = :r2_step
     FomoParameterSet{T} <: AbstractParameterSet
 
 This structure designed for `lbfgs` regroups the following parameters:
-  - `η1 = eps(T)^(1 / 4)`, `η2 = T($(FOMO_η2))`: step acceptance parameters.
+  - `η1 = $(FOMO_η1)`, `η2 = T($(FOMO_η2))`: step acceptance parameters.
   - `γ1 = T($(FOMO_γ1))`, `γ2 = T($(FOMO_γ2))`: regularization update parameters.
   - `γ3 = T($(FOMO_γ3))` : momentum factor βmax update parameter in case of unsuccessful iteration.
-  - `αmax = 1 / eps(T)`: maximum step parameter for fomo algorithm.
+  - `αmax = $(FOMO_αmax)`: maximum step parameter for fomo algorithm.
   - `β = T($(FOMO_β)) ∈ [0,1)`: target decay rate for the momentum.
   - `θ1 = T($(FOMO_θ1))`: momentum contribution parameter for convergence condition (1).
-  - `θ2 = eps(T)^(1 / 3)`: momentum contribution parameter for convergence condition (2). 
+  - `θ2 = $(FOMO_θ2)`: momentum contribution parameter for convergence condition (2). 
   - `M = $(FOMO_M)` : requires objective decrease over the `M` last iterates (nonmonotone context). `M=1` implies monotone behaviour. 
   - `step_backend = $(FOMO_step_backend)()`: step computation mode. Options are `r2_step()` for quadratic regulation step and `tr_step()` for first-order trust-region.
 
@@ -61,7 +62,7 @@ end
 
 # add a default constructor
 function FomoParameterSet{T}(;
-  η1::T = eps(T)^(1 / 4),
+  η1::T = eps(T)^(1 // 4),
   η2::T = T(FOMO_η2),
   γ1::T = T(FOMO_γ1),
   γ2::T = T(FOMO_γ2),
@@ -69,7 +70,7 @@ function FomoParameterSet{T}(;
   αmax::T = 1 / eps(T),
   β::T = T(FOMO_β),
   θ1::T = T(FOMO_θ1),
-  θ2::T = eps(T)^(1 / 3),
+  θ2::T = eps(T)^(1 // 3),
   M::Int = FOMO_M,
   step_backend::AbstractFOMethod = eval(FOMO_step_backend)(),
 ) where {T}
@@ -238,7 +239,7 @@ end
 
 @doc (@doc FomoSolver) function fomo(
   nlp::AbstractNLPModel{T, V};
-  η1::T = eps(T)^(1 / 4),
+  η1::T = eps(T)^(1 // 4),
   η2::T = T(FOMO_η2),
   γ1::T = T(FOMO_γ1),
   γ2::T = T(FOMO_γ2),
@@ -246,7 +247,7 @@ end
   αmax::T = 1 / eps(T),
   β::T = T(FOMO_β),
   θ1::T = T(FOMO_θ1),
-  θ2::T = eps(T)^(1 / 3),
+  θ2::T = eps(T)^(1 // 3),
   M::Int = FOMO_M,
   step_backend::AbstractFOMethod = eval(FOMO_step_backend)(),
   kwargs...,
@@ -375,7 +376,7 @@ Base.@deprecate R2Solver(nlp::AbstractNLPModel; kwargs...) FoSolver(
 
 @doc (@doc FoSolver) function fo(
   nlp::AbstractNLPModel{T, V};
-  η1::T = eps(T)^(1 / 4),
+  η1::T = eps(T)^(1 // 4),
   η2::T = T(FOMO_η2),
   γ1::T = T(FOMO_γ1),
   γ2::T = T(FOMO_γ2),
@@ -383,7 +384,7 @@ Base.@deprecate R2Solver(nlp::AbstractNLPModel; kwargs...) FoSolver(
   αmax::T = 1 / eps(T),
   β::T = T(FOMO_β),
   θ1::T = T(FOMO_θ1),
-  θ2::T = eps(T)^(1 / 3),
+  θ2::T = eps(T)^(1 // 3),
   M::Int = FOMO_M,
   step_backend = eval(FOMO_step_backend)(),
   kwargs...,

--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -1,5 +1,6 @@
-export lbfgs, LBFGSSolver
+export lbfgs, LBFGSSolver, LBFGSParameterSet
 
+# Default algorithm parameter values
 const LBFGS_mem = 5
 const LBFGS_τ₁ = 0.9999
 const LBFGS_bk_max = 25

--- a/src/tron.jl
+++ b/src/tron.jl
@@ -1,10 +1,11 @@
 #  Some parts of this code were adapted from
 # https://github.com/PythonOptimizers/NLP.py/blob/develop/nlp/optimize/tron.py
 
-export tron, TronSolver
+export tron, TronSolver, TRONParameterSet
 
 tron(nlp::AbstractNLPModel; variant = :Newton, kwargs...) = tron(Val(variant), nlp; kwargs...)
 
+# Default algorithm parameter values
 const TRON_μ₀ = 1 // 100
 const TRON_μ₁ = 1
 const TRON_σ = 10

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -1,9 +1,10 @@
-export TronSolverNLS
+export TronSolverNLS, TRONLSParameterSet
 
 const tronls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolver]
 
 tron(nls::AbstractNLSModel; variant = :GaussNewton, kwargs...) = tron(Val(variant), nls; kwargs...)
 
+# Default algorithm parameter values
 const TRONLS_μ₀ = 1 // 100
 const TRONLS_μ₁ = 1
 const TRONLS_σ = 10

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -2,6 +2,44 @@ export trunk, TrunkSolver
 
 trunk(nlp::AbstractNLPModel; variant = :Newton, kwargs...) = trunk(Val(variant), nlp; kwargs...)
 
+const TRUNK_bk_max = 10
+const TRUNK_monotone = true
+const TRUNK_nm_itmax = 25
+
+"""
+    TRUNKParameterSet{T} <: AbstractParameterSet
+
+This structure designed for `tron` regroups the following parameters:
+  - `bk_max::Int = $(TRUNK_bk_max)`: algorithm parameter.
+  - `monotone::Bool = $(TRUNK_monotone)`: algorithm parameter.
+  - `nm_itmax::Int = $(TRUNK_nm_itmax)`: algorithm parameter.
+
+  Default values are:
+  - `bk_max = $(TRUNK_bk_max)`
+  - `monotone = $(TRUNK_monotone)`
+  - `nm_itmax = $(TRUNK_nm_itmax)`
+"""
+struct TRUNKParameterSet{T} <: AbstractParameterSet
+  bk_max::Parameter{T, IntegerRange{T}}
+  monotone::Parameter{Bool, BinaryRange{Bool}}
+  nm_itmax::Parameter{T, IntegerRange{T}}
+end
+
+# add a default constructor
+function TRUNKParameterSet{T}(;
+  bk_max::Int = T(TRUNK_bk_max),
+  monotone::Bool = TRUNK_monotone,
+  nm_itmax::Int = T(TRUNK_nm_itmax),
+) where {T}
+  TRUNKParameterSet(
+    Parameter(bk_max, IntegerRange(T(1), typemax(T))),
+    Parameter(monotone, BinaryRange()),
+    Parameter(nm_itmax, IntegerRange(T(1), typemax(T))),
+  )
+end
+TRUNKParameterSet(bk_max::T, monotone::Bool, nm_itmax::T) where {T} =
+  TRUNKParameterSet{T}(bk_max = bk_max, monotone = monotone, nm_itmax = nm_itmax)
+
 """
     trunk(nlp; kwargs...)
 
@@ -22,9 +60,9 @@ The keyword arguments may include
 - `max_eval::Int = -1`: maximum number of objective function evaluations.
 - `max_time::Float64 = 30.0`: maximum time limit in seconds.
 - `max_iter::Int = typemax(Int)`: maximum number of iterations.
-- `bk_max::Int = 10`: algorithm parameter.
-- `monotone::Bool = true`: algorithm parameter.
-- `nm_itmax::Int = 25`: algorithm parameter.
+- `bk_max::Int = $(TRUNK_bk_max)`: algorithm parameter, see [`TRUNKParameterSet`](@ref).
+- `monotone::Bool = $(TRUNK_monotone)`: algorithm parameter, see [`TRUNKParameterSet`](@ref).
+- `nm_itmax::Int = $(TRUNK_nm_itmax)`: algorithm parameter, see [`TRUNKParameterSet`](@ref).
 - `verbose::Int = 0`: if > 0, display iteration information every `verbose` iteration.
 - `subsolver_verbose::Int = 0`: if > 0, display iteration information every `subsolver_verbose` iteration of the subsolver.
 - `M`: linear operator that models a Hermitian positive-definite matrix of size `n`; passed to Krylov subsolvers. 
@@ -84,12 +122,17 @@ mutable struct TrunkSolver{
   subsolver::Sub
   H::Op
   tr::TrustRegion{T, V}
+  params::TRUNKParameterSet{Int}
 end
 
 function TrunkSolver(
   nlp::AbstractNLPModel{T, V};
+  bk_max::Int = TRUNK_bk_max,
+  monotone::Bool = TRUNK_monotone,
+  nm_itmax::Int = TRUNK_nm_itmax,
   subsolver_type::Type{<:KrylovSolver} = CgSolver,
 ) where {T, V <: AbstractVector{T}}
+  params = TRUNKParameterSet{Int}(; bk_max = bk_max, monotone = monotone, nm_itmax = nm_itmax)
   nvar = nlp.meta.nvar
   x = V(undef, nvar)
   xt = V(undef, nvar)
@@ -102,7 +145,7 @@ function TrunkSolver(
   H = hess_op!(nlp, x, Hs)
   Op = typeof(H)
   tr = TrustRegion(gt, one(T))
-  return TrunkSolver{T, V, Sub, Op}(x, xt, gx, gt, gn, Hs, subsolver, H, tr)
+  return TrunkSolver{T, V, Sub, Op}(x, xt, gx, gt, gn, Hs, subsolver, H, tr, params)
 end
 
 function SolverCore.reset!(solver::TrunkSolver)
@@ -126,7 +169,7 @@ end
   subsolver_type::Type{<:KrylovSolver} = CgSolver,
   kwargs...,
 ) where {V}
-  solver = TrunkSolver(nlp, subsolver_type = subsolver_type)
+  solver = TrunkSolver(nlp; subsolver_type = subsolver_type)
   return solve!(solver, nlp; x = x, kwargs...)
 end
 
@@ -142,9 +185,6 @@ function SolverCore.solve!(
   max_eval::Int = -1,
   max_iter::Int = typemax(Int),
   max_time::Float64 = 30.0,
-  bk_max::Int = 10,
-  monotone::Bool = true,
-  nm_itmax::Int = 25,
   verbose::Int = 0,
   subsolver_verbose::Int = 0,
   M = I,
@@ -155,6 +195,11 @@ function SolverCore.solve!(
   if !unconstrained(nlp)
     error("trunk should only be called for unconstrained problems. Try tron instead")
   end
+
+  # parameters
+  bk_max = value(solver.params.bk_max)
+  monotone = value(solver.params.monotone)
+  nm_itmax = value(solver.params.nm_itmax)
 
   reset!(stats)
   start_time = time()

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -1,7 +1,8 @@
-export trunk, TrunkSolver
+export trunk, TrunkSolver, TRUNKParameterSet
 
 trunk(nlp::AbstractNLPModel; variant = :Newton, kwargs...) = trunk(Val(variant), nlp; kwargs...)
 
+# Default algorithm parameter values
 const TRUNK_bk_max = 10
 const TRUNK_monotone = true
 const TRUNK_nm_itmax = 25

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -1,4 +1,4 @@
-export TrunkSolverNLS, TRUNKLS_bk_max
+export TrunkSolverNLS, TRUNKLSParameterSet
 
 const trunkls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolver]
 

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -1,10 +1,11 @@
-export TrunkSolverNLS
+export TrunkSolverNLS, TRUNKLS_bk_max
 
 const trunkls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolver]
 
 trunk(nlp::AbstractNLSModel; variant = :GaussNewton, kwargs...) =
   trunk(Val(variant), nlp; kwargs...)
 
+# Default algorithm parameter values
 const TRUNKLS_bk_max = 10
 const TRUNKLS_monotone = true
 const TRUNKLS_nm_itmax = 25

--- a/src/trunkls.jl
+++ b/src/trunkls.jl
@@ -5,6 +5,44 @@ const trunkls_allowed_subsolvers = [CglsSolver, CrlsSolver, LsqrSolver, LsmrSolv
 trunk(nlp::AbstractNLSModel; variant = :GaussNewton, kwargs...) =
   trunk(Val(variant), nlp; kwargs...)
 
+const TRUNKLS_bk_max = 10
+const TRUNKLS_monotone = true
+const TRUNKLS_nm_itmax = 25
+
+"""
+    TRUNKLSParameterSet{T} <: AbstractParameterSet
+
+This structure designed for `tron` regroups the following parameters:
+  - `bk_max::Int = $(TRUNKLS_bk_max)`: algorithm parameter.
+  - `monotone::Bool = $(TRUNKLS_monotone)`: algorithm parameter.
+  - `nm_itmax::Int = $(TRUNKLS_nm_itmax)`: algorithm parameter.
+
+  Default values are:
+  - `bk_max = $(TRUNKLS_bk_max)`
+  - `monotone = $(TRUNKLS_monotone)`
+  - `nm_itmax = $(TRUNKLS_nm_itmax)`
+"""
+struct TRUNKLSParameterSet{T} <: AbstractParameterSet
+  bk_max::Parameter{T, IntegerRange{T}}
+  monotone::Parameter{Bool, BinaryRange{Bool}}
+  nm_itmax::Parameter{T, IntegerRange{T}}
+end
+
+# add a default constructor
+function TRUNKLSParameterSet{T}(;
+  bk_max::Int = T(TRUNKLS_bk_max),
+  monotone::Bool = TRUNKLS_monotone,
+  nm_itmax::Int = T(TRUNKLS_nm_itmax),
+) where {T}
+  TRUNKLSParameterSet(
+    Parameter(bk_max, IntegerRange(T(1), typemax(T))),
+    Parameter(monotone, BinaryRange()),
+    Parameter(nm_itmax, IntegerRange(T(1), typemax(T))),
+  )
+end
+TRUNKLSParameterSet(bk_max::T, monotone::Bool, nm_itmax::T) where {T} =
+  TRUNKLSParameterSet{T}(bk_max = bk_max, monotone = monotone, nm_itmax = nm_itmax)
+
 """
     trunk(nls; kwargs...)
 
@@ -28,9 +66,9 @@ The keyword arguments may include
 - `max_eval::Int = -1`: maximum number of objective function evaluations.
 - `max_time::Float64 = 30.0`: maximum time limit in seconds.
 - `max_iter::Int = typemax(Int)`: maximum number of iterations.
-- `bk_max::Int = 10`: algorithm parameter.
-- `monotone::Bool = true`: algorithm parameter.
-- `nm_itmax::Int = 25`: algorithm parameter.
+- `bk_max::Int = $(TRUNKLS_bk_max)`: algorithm parameter, see [`TRUNKLSParameterSet`](@ref).
+- `monotone::Bool = $(TRUNKLS_monotone)`: algorithm parameter, see [`TRUNKLSParameterSet`](@ref).
+- `nm_itmax::Int = $(TRUNKLS_nm_itmax)`: algorithm parameter, see [`TRUNKLSParameterSet`](@ref).
 - `verbose::Int = 0`: if > 0, display iteration details every `verbose` iteration.
 - `subsolver_verbose::Int = 0`: if > 0, display iteration information every `subsolver_verbose` iteration of the subsolver.
 
@@ -96,12 +134,17 @@ mutable struct TrunkSolverNLS{
   Atv::V
   A::Op
   subsolver::Sub
+  params::TRUNKLSParameterSet{Int}
 end
 
 function TrunkSolverNLS(
   nlp::AbstractNLPModel{T, V};
+  bk_max::Int = TRUNKLS_bk_max,
+  monotone::Bool = TRUNKLS_monotone,
+  nm_itmax::Int = TRUNKLS_nm_itmax,
   subsolver_type::Type{<:KrylovSolver} = LsmrSolver,
 ) where {T, V <: AbstractVector{T}}
+  params = TRUNKLSParameterSet{Int}(; bk_max = bk_max, monotone = monotone, nm_itmax = nm_itmax)
   subsolver_type in trunkls_allowed_subsolvers ||
     error("subproblem solver must be one of $(trunkls_allowed_subsolvers)")
 
@@ -124,7 +167,21 @@ function TrunkSolverNLS(
   subsolver = subsolver_type(nequ, nvar, V)
   Sub = typeof(subsolver)
 
-  return TrunkSolverNLS{T, V, Sub, Op}(x, xt, temp, gx, gt, tr, rt, Fx, Av, Atv, A, subsolver)
+  return TrunkSolverNLS{T, V, Sub, Op}(
+    x,
+    xt,
+    temp,
+    gx,
+    gt,
+    tr,
+    rt,
+    Fx,
+    Av,
+    Atv,
+    A,
+    subsolver,
+    params,
+  )
 end
 
 function SolverCore.reset!(solver::TrunkSolverNLS)
@@ -163,9 +220,6 @@ function SolverCore.solve!(
   max_eval::Int = -1,
   max_iter::Int = typemax(Int),
   max_time::Float64 = 30.0,
-  bk_max::Int = 10,
-  monotone::Bool = true,
-  nm_itmax::Int = 25,
   verbose::Int = 0,
   subsolver_verbose::Int = 0,
 ) where {T, V <: AbstractVector{T}}
@@ -175,6 +229,11 @@ function SolverCore.solve!(
   if !unconstrained(nlp)
     error("trunk should only be called for unconstrained problems. Try tron instead")
   end
+
+  # parameters
+  bk_max = value(solver.params.bk_max)
+  monotone = value(solver.params.monotone)
+  nm_itmax = value(solver.params.nm_itmax)
 
   reset!(stats)
   start_time = time()


### PR DESCRIPTION
This is a first draft of integrating [SolverParameters.jl](https://github.com/JuliaSmoothOptimizers/SolverParameters.jl) in the JSO-compliant solver.

It is more constraints but clarifies the role of algorithmic parameters (their default values, and their domain *-> so far we never really had a check on the domain*).

I believe this structure should be in the `solver` for one reason well illustrated here that the solver can need the parameters.

This is minimal change in the code as in the beginning we will extract the parameters from the solver structure.

What do change is that we can no longer call `solve!(solver, nlp, stats; with_some_parameters = 1)` with parameters. (although, we could update the values in the solver from the keyword arguments, but probably not a good practice)

This also opens new perspectives. For instance, the `LbfgsParameterSet` could contains parameters for a recipe to compute `mem` instead of just `mem` (if we plan something that depend on the size of the problem for instance).

*What is not done here* is where we store the default values. There should be isolated, so we can modify them easily, and also they might depend on the solver precision... An optimal τ₁ (below) is probably different in `Float16` and in `Float64`.