### PR TITLE
Add references for R2 and LBFGS in readme #236

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This package provides an implementation of four classic algorithms for unconstra
 
     
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
+
     > E. G. Birgin, J. L. Gardenghi, J. M. Martínez, S. A. Santos, Ph. L. Toint. (2017).
     > Worst-case evaluation complexity for unconstrained nonlinear optimization using
     > high-order regularized models. *Mathematical Programming*, 163(1), 359-368.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ and bound-constrained optimization
 This package provides an implementation of four classic algorithms for unconstrained/bound-constrained nonlinear optimization:
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
-    > A Paul T. Boggs, A Richard H. Byrd. (2019). Adaptive, Limited-Memory BFGS
-    > Algorithms for Unconstrained Optimization.
-    > DOI: [10.1137/16M1065100](https://epubs.siam.org/doi/abs/10.1137/16M1065100)
+    > Boggs, P. T., & Byrd, R. H. (2019). Adaptive, Limited-Memory BFGS
+    > Algorithms for Unconstrained Optimization. SIAM Journal on
+    > Optimization, 29(2), 1282-1299.
+    > DOI: 10.1137/16M1065100
     
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
   > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This package provides an implementation of four classic algorithms for unconstra
 
     
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
-     > E. G. Birgin, J. L. Gardenghi, J. M. Martínez, S. A. Santos, Ph. L. Toint. (2017).
-     > Worst-case evaluation complexity for unconstrained nonlinear optimization using
-     > high-order regularized models. *Mathematical Programming*, 163(1), 359-368.
-     > DOI: [10.1007/s10107-016-1065-8](https://doi.org/10.1007/s10107-016-1065-8)
+    > E. G. Birgin, J. L. Gardenghi, J. M. Martínez, S. A. Santos, Ph. L. Toint. (2017).
+    > Worst-case evaluation complexity for unconstrained nonlinear optimization using
+    > high-order regularized models. *Mathematical Programming*, 163(1), 359-368.
+    > DOI: [10.1007/s10107-016-1065-8](https://doi.org/10.1007/s10107-016-1065-8)
 
   
 - `tron`: a pure Julia implementation of TRON, a trust-region solver for bound-constrained optimization described in

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ and bound-constrained optimization
 This package provides an implementation of four classic algorithms for unconstrained/bound-constrained nonlinear optimization:
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
-  > Yunhai Xiao, Zengxin Wei, Zhiguo Wang, A limited memory BFGS-type method
-  > for large-scale unconstrained optimization Computers & Mathematics with
-  > Applications,Volume 56, Issue 4,2008,Pages 1001-1009,ISSN 0898-1221,
-  > DOI: [10.1016/j.camwa.2008.01.028.](https://doi.org/10.1016/j.camwa.2008.01.028.)
-  
+    > A Paul T. Boggs, A Richard H. Byrd. (2019). Adaptive, Limited-Memory BFGS
+    > Algorithms for Unconstrained Optimization.
+    > DOI: [10.1137/16M1065100](https://epubs.siam.org/doi/abs/10.1137/16M1065100)
+    
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
   > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic
   > Regularization Method for Unconstrained Optimization with Rounding Error Analysis.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package provides an implementation of four classic algorithms for unconstra
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
   > Yunhai Xiao, Zengxin Wei, Zhiguo Wang, A limited memory BFGS-type method
-  > for large-scale unconstrained optimizationComputers & Mathematics with
+  > for large-scale unconstrained optimization Computers & Mathematics with
   > Applications,Volume 56, Issue 4,2008,Pages 1001-1009,ISSN 0898-1221,
   > DOI: [j.camwa.2008.01.028.](https://doi.org/10.1016/j.camwa.2008.01.028.)
   

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package provides an implementation of four classic algorithms for unconstra
     > Boggs, P. T., & Byrd, R. H. (2019). Adaptive, Limited-Memory BFGS
     > Algorithms for Unconstrained Optimization. SIAM Journal on
     > Optimization, 29(2), 1282-1299.
-    > DOI: 10.1137/16M1065100
+    > DOI: [10.1137/16M1065100](https://doi.org/10.1137/16M1065100)
     
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
   > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic

--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ and bound-constrained optimization
 This package provides an implementation of four classic algorithms for unconstrained/bound-constrained nonlinear optimization:
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
+  > Yunhai Xiao, Zengxin Wei, Zhiguo Wang, A limited memory BFGS-type method
+  > for large-scale unconstrained optimizationComputers & Mathematics with
+  > Applications,Volume 56, Issue 4,2008,Pages 1001-1009,ISSN 0898-1221,
+  > DOI: [j.camwa.2008.01.028.](https://doi.org/10.1016/j.camwa.2008.01.028.)
+  
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
+  > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic
+  > Regularization Method for Unconstrained Optimization with Rounding Error Analysis.
+  > DOI: [10.13140/RG.2.2.22068.01926.](http://dx.doi.org/10.13140/RG.2.2.22068.01926) 
 - `tron`: a pure Julia implementation of TRON, a trust-region solver for bound-constrained optimization described in
 
     >  Chih-Jen Lin and Jorge J. Moré, *Newton's Method for Large Bound-Constrained

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ and bound-constrained optimization
 This package provides an implementation of four classic algorithms for unconstrained/bound-constrained nonlinear optimization:
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
-    > Boggs, P. T., & Byrd, R. H. (2019). Adaptive, Limited-Memory BFGS
-    > Algorithms for Unconstrained Optimization. SIAM Journal on
-    > Optimization, 29(2), 1282-1299.
-    > DOI: [10.1137/16M1065100](https://doi.org/10.1137/16M1065100)
+    > D. C. Liu, J. Nocedal. (1989). On the limited memory BFGS method for
+    > large scale optimization. *Mathematical Programming*, 45(1), 503-528.
+    > DOI: [10.1007/BF01589116](https://doi.org/10.1007/BF01589116)
+
     
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
-  > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic
-  > Regularization Method for Unconstrained Optimization with Rounding Error Analysis.
-  > DOI: [10.13140/RG.2.2.22068.01926.](http://dx.doi.org/10.13140/RG.2.2.22068.01926) 
+     > E. G. Birgin, J. L. Gardenghi, J. M. Martínez, S. A. Santos, Ph. L. Toint. (2017).
+     > Worst-case evaluation complexity for unconstrained nonlinear optimization using
+     > high-order regularized models. *Mathematical Programming*, 163(1), 359-368.
+     > DOI: [10.1007/s10107-016-1065-8](https://doi.org/10.1007/s10107-016-1065-8)
+
+  
 - `tron`: a pure Julia implementation of TRON, a trust-region solver for bound-constrained optimization described in
 
     >  Chih-Jen Lin and Jorge J. Moré, *Newton's Method for Large Bound-Constrained

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package provides an implementation of four classic algorithms for unconstra
   > Yunhai Xiao, Zengxin Wei, Zhiguo Wang, A limited memory BFGS-type method
   > for large-scale unconstrained optimization Computers & Mathematics with
   > Applications,Volume 56, Issue 4,2008,Pages 1001-1009,ISSN 0898-1221,
-  > DOI: [j.camwa.2008.01.028.](https://doi.org/10.1016/j.camwa.2008.01.028.)
+  > DOI: [10.1016/j.camwa.2008.01.028.](https://doi.org/10.1016/j.camwa.2008.01.028.)
   
 - `R2`: a first-order quadratic regularization method for unconstrained optimization;
   > Monnet, Dominique & Orban, Dominique. (2023). A Multi-Precision Quadratic

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and bound-constrained optimization
 This package provides an implementation of four classic algorithms for unconstrained/bound-constrained nonlinear optimization:
 
 - `lbfgs`: an implementation of a limited-memory BFGS line-search method for unconstrained minimization;
+
     > D. C. Liu, J. Nocedal. (1989). On the limited memory BFGS method for
     > large scale optimization. *Mathematical Programming*, 45(1), 503-528.
     > DOI: [10.1007/BF01589116](https://doi.org/10.1007/BF01589116)


### PR DESCRIPTION
This pull request addresses issue #236 by adding references for the R2 and LBFGS implementations in the project's readme. 

Changes Made:

* Added references for the R2 implementation in the readme.
* Included references for the LBFGS implementation in the readme.

Related Issue:
Closes #236