### PR TITLE
Fomo nonmonotone extension

### DIFF
--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -22,7 +22,7 @@ and βmax ∈ [0,β] chosen as to ensure d is gradient-related, i.e., the follow
 ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) *. ∇f(xk) + βmax .* mk‖       (2)
 In the nonmonotone case, (1) rewrites
 (1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk + (fm - fk)/μk ≥ θ1 * ‖∇f(xk)‖²,
-with fm the greatest objective value over the last M successful iterations, and fk = f(xk).
+with fm the largest objective value over the last M successful iterations, and fk = f(xk).
 
 # Advanced usage
 

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -21,7 +21,7 @@ and βmax ∈ [0,β] chosen as to ensure d is gradient-related, i.e., the follow
 (1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk ≥ θ1 * ‖∇f(xk)‖² (1)
 ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) *. ∇f(xk) + βmax .* mk‖       (2)
 In the nonmonotone case, (1) rewrites
-(1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk + (fm - fk)/μk≥ θ1 * ‖∇f(xk)‖²,
+(1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk + (fm - fk)/μk ≥ θ1 * ‖∇f(xk)‖²,
 with fm the greatest objective value over the last M successful iterations, and fk = f(xk).
 
 # Advanced usage
@@ -122,7 +122,7 @@ function FomoSolver(nlp::AbstractNLPModel{T, V}; M::Int=1) where {T, V}
   m = fill!(similar(nlp.meta.x0), 0)
   d = fill!(similar(nlp.meta.x0), 0)
   p = similar(nlp.meta.x0)
-  o = fill!(Vector{T}(undef,M),-Inf)
+  o = fill!(Vector{T}(undef, M), -Inf)
   return FomoSolver{T, V}(x, g, c, m, d, p, o, T(0))
 end
 
@@ -135,7 +135,7 @@ end
 
 function SolverCore.reset!(solver::FomoSolver{T}) where {T}
   fill!(solver.m, 0)
-  fill!(solver.o,-Inf)
+  fill!(solver.o, -Inf)
   solver
 end
 
@@ -217,7 +217,7 @@ function FoSolver(nlp::AbstractNLPModel{T, V}; M::Int = 1) where {T, V}
   x = similar(nlp.meta.x0)
   g = similar(nlp.meta.x0)
   c = similar(nlp.meta.x0)
-  o = fill!(Vector{T}(undef,M),-Inf)
+  o = fill!(Vector{T}(undef,M), -Inf)
   return FoSolver{T, V}(x, g, c, o, T(0))
 end
 
@@ -247,7 +247,7 @@ end
 end
 
 function SolverCore.reset!(solver::FoSolver{T}) where {T}
-  fill!(solver.o,-Inf)
+  fill!(solver.o, -Inf)
   solver
 end
 
@@ -386,7 +386,7 @@ function SolverCore.solve!(
         momentum .= ∇fk .* (oneT - β) .+ momentum .* β
       end
       set_objective!(stats, fck)
-      circshift!(obj_mem,1)
+      circshift!(obj_mem, 1)
       obj_mem[1] = stats.objective
       max_obj_mem = maximum(obj_mem)
 
@@ -450,7 +450,7 @@ function SolverCore.solve!(
 end
 
 """
-find_beta(m, mdot∇f, norm_∇f, μk, fk, max_obj_mem, β, θ1, θ2)
+    find_beta(m, mdot∇f, norm_∇f, μk, fk, max_obj_mem, β, θ1, θ2)
 
 Compute βmax which saturates the contibution of the momentum term to the gradient.
 `βmax` is computed such that the two gradient-related conditions (first one is relaxed in the nonmonotone case) are ensured: 

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -458,7 +458,7 @@ end
 """
     find_beta(m, mdot∇f, norm_∇f, μk, fk, max_obj_mem, β, θ1, θ2)
 
-Compute βmax which saturates the contibution of the momentum term to the gradient.
+Compute βmax which saturates the contribution of the momentum term to the gradient.
 `βmax` is computed such that the two gradient-related conditions (first one is relaxed in the nonmonotone case) are ensured: 
 1. (1-βmax) * ‖∇f(xk)‖² + βmax * ∇f(xk)ᵀm + (max_obj_mem - fk)/μk ≥ θ1 * ‖∇f(xk)‖²
 2. ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) * ∇f(xk) .+ βmax .* m‖

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -23,9 +23,6 @@ and βmax ∈ [0,β] chosen as to ensure d is gradient-related, i.e., the follow
 In the nonmonotone case, (1) rewrites
 (1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk + (fm - fk)/μk ≥ θ1 * ‖∇f(xk)‖²,
 with fm the greatest objective value over the last M successful iterations, and fk = f(xk).
-In the nonmonotone case, (1) rewrites
-(1-βmax) .* ∇f(xk) + βmax .* ∇f(xk)ᵀmk + (fm - fk)/μk ≥ θ1 * ‖∇f(xk)‖²,
-with fm the greatest objective value over the last M successful iterations, and fk = f(xk).
 
 # Advanced usage
 
@@ -118,7 +115,7 @@ mutable struct FomoSolver{T, V} <: AbstractFirstOrderSolver
   α::T
 end
 
-function FomoSolver(nlp::AbstractNLPModel{T, V}; M::Int=1) where {T, V}
+function FomoSolver(nlp::AbstractNLPModel{T, V}; M::Int = 1) where {T, V}
   x = similar(nlp.meta.x0)
   g = similar(nlp.meta.x0)
   c = similar(nlp.meta.x0)
@@ -129,7 +126,11 @@ function FomoSolver(nlp::AbstractNLPModel{T, V}; M::Int=1) where {T, V}
   return FomoSolver{T, V}(x, g, c, m, d, p, o, T(0))
 end
 
-@doc (@doc FomoSolver) function fomo(nlp::AbstractNLPModel{T, V}; M::Int = 1, kwargs...) where {T, V}
+@doc (@doc FomoSolver) function fomo(
+  nlp::AbstractNLPModel{T, V};
+  M::Int = 1,
+  kwargs...,
+) where {T, V}
   solver = FomoSolver(nlp; M)
   solver_specific = Dict(:avgβmax => T(0.0))
   stats = GenericExecutionStats(nlp; solver_specific = solver_specific)
@@ -220,7 +221,7 @@ function FoSolver(nlp::AbstractNLPModel{T, V}; M::Int = 1) where {T, V}
   x = similar(nlp.meta.x0)
   g = similar(nlp.meta.x0)
   c = similar(nlp.meta.x0)
-  o = fill!(Vector{T}(undef,M), -Inf)
+  o = fill!(Vector{T}(undef, M), -Inf)
   return FoSolver{T, V}(x, g, c, o, T(0))
 end
 
@@ -370,7 +371,7 @@ function SolverCore.solve!(
     ΔTk = ((oneT - βmax) * norm_∇fk^2 + βmax * mdot∇f) * μk # = dot(d,∇fk) * μk with momentum, ‖∇fk‖²μk without momentum
     fck = obj(nlp, c)
     unbounded = fck < fmin
-    ρk = (max_obj_mem - fck) /(max_obj_mem - stats.objective + ΔTk) 
+    ρk = (max_obj_mem - fck) / (max_obj_mem - stats.objective + ΔTk)
     # Update regularization parameters
     if ρk >= η2
       solver.α = min(αmax, γ2 * solver.α)
@@ -461,10 +462,20 @@ Compute βmax which saturates the contibution of the momentum term to the gradie
 2. ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) * ∇f(xk) .+ βmax .* m‖
 with `m` the momentum term and `mdot∇f = ∇f(xk)ᵀm`, `fk` the model at s=0, `max_obj_mem` the greatest value of objective over the last M successful iterations.
 """
-function find_beta(p::V, mdot∇f::T, norm_∇f::T, μk::T, fk::T, max_obj_mem::T, β::T, θ1::T, θ2::T) where {T, V}
+function find_beta(
+  p::V,
+  mdot∇f::T,
+  norm_∇f::T,
+  μk::T,
+  fk::T,
+  max_obj_mem::T,
+  β::T,
+  θ1::T,
+  θ2::T,
+) where {T, V}
   n1 = norm_∇f^2 - mdot∇f
   n2 = norm(p)
-  β1 = n1 > 0 ? ((1 - θ1) * norm_∇f^2 - (fk - max_obj_mem)/μk ) / n1 : β
+  β1 = n1 > 0 ? ((1 - θ1) * norm_∇f^2 - (fk - max_obj_mem) / μk) / n1 : β
   β2 = n2 != 0 ? (1 - θ2) * norm_∇f / n2 : β
   return min(β, min(β1, β2))
 end

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -462,7 +462,7 @@ Compute βmax which saturates the contribution of the momentum term to the gradi
 `βmax` is computed such that the two gradient-related conditions (first one is relaxed in the nonmonotone case) are ensured: 
 1. (1-βmax) * ‖∇f(xk)‖² + βmax * ∇f(xk)ᵀm + (max_obj_mem - fk)/μk ≥ θ1 * ‖∇f(xk)‖²
 2. ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) * ∇f(xk) .+ βmax .* m‖
-with `m` the momentum term and `mdot∇f = ∇f(xk)ᵀm`, `fk` the model at s=0, `max_obj_mem` the largest value of objective over the last M successful iterations.
+with `m` the momentum term and `mdot∇f = ∇f(xk)ᵀm`, `fk` the model at s=0, `max_obj_mem` the largest objective value over the last M successful iterations.
 """
 function find_beta(
   p::V,

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -462,7 +462,7 @@ Compute βmax which saturates the contribution of the momentum term to the gradi
 `βmax` is computed such that the two gradient-related conditions (first one is relaxed in the nonmonotone case) are ensured: 
 1. (1-βmax) * ‖∇f(xk)‖² + βmax * ∇f(xk)ᵀm + (max_obj_mem - fk)/μk ≥ θ1 * ‖∇f(xk)‖²
 2. ‖∇f(xk)‖ ≥ θ2 * ‖(1-βmax) * ∇f(xk) .+ βmax .* m‖
-with `m` the momentum term and `mdot∇f = ∇f(xk)ᵀm`, `fk` the model at s=0, `max_obj_mem` the greatest value of objective over the last M successful iterations.
+with `m` the momentum term and `mdot∇f = ∇f(xk)ᵀm`, `fk` the model at s=0, `max_obj_mem` the largest value of objective over the last M successful iterations.
 """
 function find_beta(
   p::V,

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -298,7 +298,9 @@ function SolverCore.solve!(
   f0 = obj(nlp, x)
   set_objective!(stats, f0)
   obj_mem = solver.o
-  obj_mem[1] = stats.objective
+  M = length(obj_mem)
+  mem_ind = 0
+  obj_mem[mem_ind+1] = stats.objective
   max_obj_mem = stats.objective
 
   grad!(nlp, x, ∇fk)
@@ -390,8 +392,8 @@ function SolverCore.solve!(
         momentum .= ∇fk .* (oneT - β) .+ momentum .* β
       end
       set_objective!(stats, fck)
-      circshift!(obj_mem, 1)
-      obj_mem[1] = stats.objective
+      mem_ind = (mem_ind+1) % M
+      obj_mem[mem_ind+1] = stats.objective
       max_obj_mem = maximum(obj_mem)
 
       grad!(nlp, x, ∇fk)

--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -153,6 +153,8 @@ function SolverCore.solve!(
   verbose > 0 && @info log_row(Any[stats.iter, f, ∇fNorm, T, Int])
 
   optimal = ∇fNorm ≤ ϵ
+  fmin = min(-one(T), f) / eps(T)
+  unbounded = f < fmin
 
   set_status!(
     stats,
@@ -160,6 +162,7 @@ function SolverCore.solve!(
       nlp,
       elapsed_time = stats.elapsed_time,
       optimal = optimal,
+      unbounded = unbounded,
       max_eval = max_eval,
       iter = stats.iter,
       max_iter = max_iter,
@@ -210,6 +213,7 @@ function SolverCore.solve!(
     set_time!(stats, time() - start_time)
     set_dual_residual!(stats, ∇fNorm)
     optimal = ∇fNorm ≤ ϵ
+    unbounded = f < fmin
 
     set_status!(
       stats,
@@ -217,6 +221,7 @@ function SolverCore.solve!(
         nlp,
         elapsed_time = stats.elapsed_time,
         optimal = optimal,
+        unbounded = unbounded,
         max_eval = max_eval,
         iter = stats.iter,
         max_iter = max_iter,

--- a/src/trunk.jl
+++ b/src/trunk.jl
@@ -196,6 +196,8 @@ function SolverCore.solve!(
   set_objective!(stats, f)
   set_dual_residual!(stats, ∇fNorm2)
   optimal = ∇fNorm2 ≤ ϵ
+  fmin = min(-one(T), f) / eps(T)
+  unbounded = f < fmin
 
   verbose > 0 && @info log_header(
     [:iter, :f, :dual, :radius, :ratio, :inner, :bk, :cgstatus],
@@ -210,6 +212,7 @@ function SolverCore.solve!(
       nlp,
       elapsed_time = stats.elapsed_time,
       optimal = optimal,
+      unbounded = unbounded,
       max_eval = max_eval,
       iter = stats.iter,
       max_iter = max_iter,
@@ -381,6 +384,7 @@ function SolverCore.solve!(
     update!(tr, sNorm)
 
     optimal = ∇fNorm2 ≤ ϵ
+    unbounded = f < fmin
 
     set_status!(
       stats,
@@ -388,6 +392,7 @@ function SolverCore.solve!(
         nlp,
         elapsed_time = stats.elapsed_time,
         optimal = optimal,
+        unbounded = unbounded,
         max_eval = max_eval,
         iter = stats.iter,
         max_iter = max_iter,

--- a/test/allocs.jl
+++ b/test/allocs.jl
@@ -35,7 +35,9 @@ if Sys.isunix()
       for model in NLPModelsTest.nlp_problems
         nlp = eval(Meta.parse(model))()
         if unconstrained(nlp) || (bound_constrained(nlp) && (symsolver == :TronSolver))
-          solver = eval(symsolver)(nlp)
+          if (symsolver == :FoSolver || symsolver == :FomoSolver)
+            solver = eval(symsolver)(nlp; M = 2) # nonmonotone configuration allocates extra memory
+          end
           if symsolver == :FomoSolver
             T = eltype(nlp.meta.x0)
             stats = GenericExecutionStats(nlp, solver_specific = Dict(:avgβmax => T(0)))

--- a/test/allocs.jl
+++ b/test/allocs.jl
@@ -37,6 +37,8 @@ if Sys.isunix()
         if unconstrained(nlp) || (bound_constrained(nlp) && (symsolver == :TronSolver))
           if (symsolver == :FoSolver || symsolver == :FomoSolver)
             solver = eval(symsolver)(nlp; M = 2) # nonmonotone configuration allocates extra memory
+          else
+            solver = eval(symsolver)(nlp)
           end
           if symsolver == :FomoSolver
             T = eltype(nlp.meta.x0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,19 @@ end
   end
 end
 
+@testset "Test unbounded below" begin
+  @testset "$fun" for fun in (R2, fomo, lbfgs, tron, trunk)
+    T = Float64
+    x0 = [T(0)]
+    f(x) = -exp(x[1])
+    nlp = ADNLPModel(f, x0)
+
+    stats = eval(fun)(nlp)
+    @test stats.status == :unbounded
+    @test stats.objective < -one(T)/eps(T)
+  end
+end
+
 include("restart.jl")
 include("callback.jl")
 include("consistency.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ end
 
     stats = eval(fun)(nlp)
     @test stats.status == :unbounded
-    @test stats.objective < -one(T)/eps(T)
+    @test stats.objective < -one(T) / eps(T)
   end
 end
 

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -14,6 +14,14 @@ function tests()
         unconstrained_nlp(solver)
         multiprecision_nlp(solver, :unc)
       end
+      @testset "$name : nonmonotone configuration" for (name, solver) in [
+        ("R2", (nlp; kwargs...) -> R2(nlp, M = 2; kwargs...)),
+        ("fomo_r2", (nlp; kwargs...) -> fomo(nlp, M = 2; kwargs...)),
+        ("fomo_tr", (nlp; kwargs...) -> fomo(nlp, M = 2, step_backend = JSOSolvers.tr_step(); kwargs...)),
+      ]
+        unconstrained_nlp(solver)
+        multiprecision_nlp(solver, :unc)
+      end
     end
     @testset "Bound-constrained solvers" begin
       @testset "$solver" for solver in [tron]


### PR DESCRIPTION
Add non-monotone strategy to `fomo` solver.
Modifies conditions on momentum contribution.

Related paper can be shared upon request.