### PR TITLE
Add unbounded objective tests

### DIFF
--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -279,8 +279,8 @@ function SolverCore.solve!(
   d = use_momentum ? solver.d : solver.g # g = d if no momentum
   p = use_momentum ? solver.p : nothing # not used if no momentum
   set_iter!(stats, 0)
-  fk = obj(nlp, x)
-  set_objective!(stats, fk)
+  f0 = obj(nlp, x)
+  set_objective!(stats, f0)
 
   grad!(nlp, x, ∇fk)
   norm_∇fk = norm(∇fk)
@@ -289,8 +289,8 @@ function SolverCore.solve!(
   solver.α = init_alpha(norm_∇fk, step_backend)
 
   # Stopping criterion: 
-  fmin = min(-one(T), fk) / eps(T)
-  unbounded = fk < fmin
+  fmin = min(-one(T), f0) / eps(T)
+  unbounded = f0 < fmin
 
   ϵ = atol + rtol * norm_∇fk
   optimal = norm_∇fk ≤ ϵ

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -279,7 +279,8 @@ function SolverCore.solve!(
   d = use_momentum ? solver.d : solver.g # g = d if no momentum
   p = use_momentum ? solver.p : nothing # not used if no momentum
   set_iter!(stats, 0)
-  set_objective!(stats, obj(nlp, x))
+  fk = obj(nlp, x)
+  set_objective!(stats, fk)
 
   grad!(nlp, x, ∇fk)
   norm_∇fk = norm(∇fk)
@@ -288,6 +289,9 @@ function SolverCore.solve!(
   solver.α = init_alpha(norm_∇fk, step_backend)
 
   # Stopping criterion: 
+  fmin = min(-one(T), fk) / eps(T)
+  unbounded = fk < fmin
+
   ϵ = atol + rtol * norm_∇fk
   optimal = norm_∇fk ≤ ϵ
   step_param_name = is_r2 ? "σ" : "Δ"
@@ -321,6 +325,7 @@ function SolverCore.solve!(
       nlp,
       elapsed_time = stats.elapsed_time,
       optimal = optimal,
+      unbounded = unbounded,
       max_eval = max_eval,
       iter = stats.iter,
       max_iter = max_iter,
@@ -346,7 +351,7 @@ function SolverCore.solve!(
     step_underflow = x == c # step addition underfow on every dimensions, should happen before solver.α == 0
     ΔTk = ((oneT - βmax) * norm_∇fk^2 + βmax * mdot∇f) * λk # = dot(d,∇fk) * λk with momentum, ‖∇fk‖²λk without momentum
     fck = obj(nlp, c)
-    unbounded = isinf(fck)
+    unbounded = fck < fmin
     ρk = (stats.objective - fck) / ΔTk
     # Update regularization parameters
     if ρk >= η2

--- a/src/fomo.jl
+++ b/src/fomo.jl
@@ -346,10 +346,7 @@ function SolverCore.solve!(
     step_underflow = x == c # step addition underfow on every dimensions, should happen before solver.α == 0
     ΔTk = ((oneT - βmax) * norm_∇fk^2 + βmax * mdot∇f) * λk # = dot(d,∇fk) * λk with momentum, ‖∇fk‖²λk without momentum
     fck = obj(nlp, c)
-    if fck == -Inf
-      set_status!(stats, :unbounded)
-      break
-    end
+    unbounded = isinf(fck)
     ρk = (stats.objective - fck) / ΔTk
     # Update regularization parameters
     if ρk >= η2
@@ -406,6 +403,7 @@ function SolverCore.solve!(
         nlp,
         elapsed_time = stats.elapsed_time,
         optimal = optimal,
+        unbounded = unbounded,
         max_eval = max_eval,
         iter = stats.iter,
         max_iter = max_iter,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,11 +37,14 @@ end
 
 @testset "Test unbounded below" begin
   @testset "$fun" for fun in (R2, fomo, lbfgs, tron, trunk)
+    T = Float64
+    x0 = [T(0)]
     f(x) = -exp(x[1])
-    nlp = ADNLPModel(f, [2.])
+    nlp = ADNLPModel(f, x0)
 
     stats = eval(fun)(nlp)
     @test stats.status == :unbounded
+    @test stats.objective < -one(T)/eps(T)
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,16 @@ end
   end
 end
 
+@testset "Test unbounded below" begin
+  @testset "$fun" for fun in (R2, fomo, lbfgs, tron, trunk)
+    f(x) = -exp(x[1])
+    nlp = ADNLPModel(f, [2.])
+
+    stats = eval(fun)(nlp)
+    @test stats.status == :unbounded
+  end
+end
+
 include("restart.jl")
 include("callback.jl")
 include("consistency.jl")


### PR DESCRIPTION
Looks like lbfgs doesn't detect unbounded objective.
Trunk subsolver errors (not a descent direction) before unbounded happen (if it happen). Maybe the subsolver crashes because under/overflow due to large value of the gradient.
`fomo` set status to unbounded whenever objective value overflow (`-Inf`) while `tron` uses `fx < min(-one(T), f0) / eps(T)` conditions.
I would be nice to have the same condition.