### PR TITLE
Support Krylov.jl v0.10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   matrix:
     - name: FreeBSD
       freebsd_instance:
-        image_family: freebsd-13-3
+        image_family: freebsd-14-2
       env:
         matrix:
           - JULIA_VERSION: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        version: ['lts', '1']
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [x64]
         allow_failure: [false]
         include:
+          - version: '1'
+            os: ubuntu-24.04-arm
+            arch: arm64
+            allow_failure: false
           - version: '1'
             os: macos-latest
             arch: arm64
@@ -35,8 +39,8 @@ jobs:
             arch: x64
             allow_failure: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -53,6 +57,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -15,14 +15,14 @@ SolverParameters = "d076d87d-d1f9-4ea3-a44b-64b4cdd1e470"
 SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
-Krylov = "0.9.6"
+Krylov = "0.10.0"
 LinearOperators = "2.0"
 NLPModels = "0.21"
 NLPModelsModifiers = "0.7"
 SolverCore = "0.3"
 SolverParameters = "0.1"
 SolverTools = "0.9"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"

--- a/src/tron.jl
+++ b/src/tron.jl
@@ -136,7 +136,7 @@ mutable struct TronSolver{
 
   ifix::BitVector
 
-  cg_solver::CgSolver{T, T, V}
+  cg_solver::CgWorkspace{T, T, V}
   cg_rhs::V
   cg_op_diag::V
   cg_op::LinearOperator{T}
@@ -175,7 +175,7 @@ function TronSolver(
   cg_op = opDiagonal(cg_op_diag)
 
   ZHZ = cg_op' * H * cg_op
-  cg_solver = CgSolver(ZHZ, Hs)
+  workspace = CgWorkspace(ZHZ, Hs)
   return TronSolver{T, V, Op, typeof(ZHZ)}(
     x,
     xc,
@@ -189,7 +189,7 @@ function TronSolver(
     H,
     tr,
     ifix,
-    cg_solver,
+    workspace,
     cg_rhs,
     cg_op_diag,
     cg_op,
@@ -637,7 +637,7 @@ function projected_newton!(
       cg_op_diag[i] = ifix[i] ? 0 : 1 # implictly changes cg_op and so ZHZ
     end
 
-    Krylov.cg!(
+    cg!(
       cg_solver,
       ZHZ,
       cgs_rhs,

--- a/src/tronls.jl
+++ b/src/tronls.jl
@@ -120,7 +120,7 @@ stats = solve!(solver, nls)
 mutable struct TronSolverNLS{
   T,
   V <: AbstractVector{T},
-  Sub <: KrylovSolver{T, T, V},
+  Sub <: KrylovWorkspace{T, T, V},
   Op <: AbstractLinearOperator{T},
   Aop <: AbstractLinearOperator{T},
 } <: AbstractOptimizationSolver

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 using Printf, LinearAlgebra, Logging, SparseArrays, Test
 
 # additional packages
-using ADNLPModels, Krylov, LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverTools
+using ADNLPModels, LinearOperators, NLPModels, NLPModelsModifiers, SolverCore, SolverTools
 using NLPModelsTest
 
 # this package

--- a/test/solvers/trunkls.jl
+++ b/test/solvers/trunkls.jl
@@ -4,7 +4,7 @@
   model = ADNLSModel(x -> [10 * (x[2] - x[1]^2), 1 - x[1]], [-2.0, 1.0], 2)
   for subsolver in JSOSolvers.trunkls_allowed_subsolvers
     stats = with_logger(NullLogger()) do
-      trunk(model, subsolver_type = subsolver)
+      trunk(model, subsolver = subsolver)
     end
     @test stats.status == :first_order
     @test stats.solution_reliable
@@ -16,7 +16,7 @@
     NLPModels.reset!(model)
   end
 
-  @test_throws ErrorException trunk(model, subsolver_type = MinresSolver)
+  @test_throws ErrorException trunk(model, subsolver = :minres)
 end
 
 @testset "Larger test" begin
@@ -28,7 +28,7 @@ end
   )
   for subsolver in JSOSolvers.trunkls_allowed_subsolvers
     stats = with_logger(NullLogger()) do
-      trunk(model, subsolver_type = subsolver)
+      trunk(model, subsolver = subsolver)
     end
     @test stats.status == :first_order
     @test stats.objective_reliable

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -4,7 +4,7 @@ function tests()
   @testset "Testing NLP solvers" begin
     @testset "Unconstrained solvers" begin
       @testset "$name" for (name, solver) in [
-        ("trunk+cg", (nlp; kwargs...) -> trunk(nlp, subsolver_type = CgSolver; kwargs...)),
+        ("trunk+cg", (nlp; kwargs...) -> trunk(nlp, subsolver = :cg; kwargs...)),
         ("lbfgs", lbfgs),
         ("tron", tron),
         ("R2", R2),
@@ -37,9 +37,9 @@ function tests()
   @testset "Testing NLS solvers" begin
     @testset "Unconstrained solvers" begin
       @testset "$name" for (name, solver) in [
-        ("trunk+cgls", (nls; kwargs...) -> trunk(nls, subsolver_type = CglsSolver; kwargs...)), # trunk with cgls due to multiprecision
+        ("trunk+cgls", (nls; kwargs...) -> trunk(nls, subsolver = :cgls; kwargs...)), # trunk with cgls due to multiprecision
         ("trunk full Hessian", (nls; kwargs...) -> trunk(nls, variant = :Newton; kwargs...)),
-        ("tron+cgls", (nls; kwargs...) -> tron(nls, subsolver_type = CglsSolver; kwargs...)),
+        ("tron+cgls", (nls; kwargs...) -> tron(nls, subsolver = :cgls; kwargs...)),
         ("tron full Hessian", (nls; kwargs...) -> tron(nls, variant = :Newton; kwargs...)),
       ]
         unconstrained_nls(solver)
@@ -48,7 +48,7 @@ function tests()
     end
     @testset "Bound-constrained solvers" begin
       @testset "$name" for (name, solver) in [
-        ("tron+cgls", (nls; kwargs...) -> tron(nls, subsolver_type = CglsSolver; kwargs...)),
+        ("tron+cgls", (nls; kwargs...) -> tron(nls, subsolver = :cgls; kwargs...)),
         ("tron full Hessian", (nls; kwargs...) -> tron(nls, variant = :Newton; kwargs...)),
       ]
         bound_constrained_nls(solver)


### PR DESCRIPTION
@tmigot @dpo 
I started to update `JSOSolvers.jl` to use Krylov.jl v0.10.
We probably need to update some dependencies in JSO before.

The new generic interface of Krylov.jl helps because the user doesn't need anymore to load `Krylov.jl` or know the internal of it to switch the subsolver.
We can just specify the subsolver with a symbol now like `:cg`, `:lsmr`, etc...

The last release of Krylov.jl requires the version 1.10 of Julia (LTS) so you will need to update the compat of Julia for all packages if you want to upgrade it.