### PR TITLE
Version 0.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSOSolvers"
 uuid = "10dff2fc-5484-5881-a0e0-c90441020f8a"
-version = "0.13.2"
+version = "0.14.0"
 
 [deps]
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"


### PR DESCRIPTION
New things:
- drop support for Julia 1.6
- Bump to Krylov 0.10
- `subsolver_type` becomes `subsolver` and take a symbol corresponding to the solver function and not the structure.