### PR TITLE
Changement du domaine admissible pour le paramètre `mem` dans l’algorithme `lbfgs`

### DIFF
--- a/src/lbfgs.jl
+++ b/src/lbfgs.jl
@@ -38,7 +38,7 @@ function LBFGSParameterSet(
   bk_max::Int = get(LBFGS_bk_max, nlp),
 ) where {T}
   LBFGSParameterSet(
-    Parameter(mem, IntegerRange(Int(5), Int(20))),
+    Parameter(mem, IntegerRange(Int(1), Int(100))),
     Parameter(τ₁, RealInterval(T(0), T(1), lower_open = true)),
     Parameter(bk_max, IntegerRange(Int(1), Int(100))),
   )


### PR DESCRIPTION
Ce commit modifie l’intervalle des valeurs autorisées pour le paramètre `mem` (mémoire limitée de L-BFGS) dans le constructeur `LBFGSParameterSet`.

L’intervalle d'entiers initial était restreint à `mem ∈ [|5, 20|]` ; il est désormais élargi à `mem ∈ [|1, 100|]`.

---
###  Changement effectué dans :

```{julia}
Parameter(mem, IntegerRange(Int(5), Int(20)))  →  Parameter(mem, IntegerRange(Int(1), Int(100)))
```
